### PR TITLE
Harden health checks and indexer

### DIFF
--- a/cache/console-history.txt
+++ b/cache/console-history.txt
@@ -1,7 +1,7 @@
-(await (await ethers.getContractAt("TransferRegistry", process.env.TRANSFER)).paused())
-(await ethers.provider.getCode(process.env.TRANSFER)) !== '0x'
-const dotenv=require('dotenv');dotenv.config();
-npx hardhat run scripts/fix-roles.ts --network localhost
-tr.interface.fragments.map(f => f.format()).filter(x => x.includes("("))
-const tr = await ethers.getContractAt("TransferRegistry", process.env.TRANSFER)
-await ethers.provider.getCode("0x9fE46736679d2D9a65F0992F2272dE9f3c7fa6e0")
+const dotenv=require('dotenv'); dotenv.config();
+const addr = process.env.TRANSFER;
+(await ethers.provider.getCode(addr)) !== '0x'
+const tr = await ethers.getContractAt("TransferRegistry", addr);
+tr.interface.fragments
+  .filter(f => f.type === "function")
+  .map(f => f.format());

--- a/indexer/indexer.ts
+++ b/indexer/indexer.ts
@@ -1,52 +1,163 @@
 import { ethers } from "ethers";
 import { PrismaClient } from "@prisma/client";
 import * as dotenv from "dotenv";
+import TransferRegistryArtifact from "../artifacts/contracts/TransferRegistry.sol/TransferRegistry.json";
+import PrizePoolArtifact from "../artifacts/contracts/PrizePool.sol/PrizePool.json";
+import SponsorshipRegistryArtifact from "../artifacts/contracts/SponsorshipRegistry.sol/SponsorshipRegistry.json";
+import DisciplinaryRegistryArtifact from "../artifacts/contracts/DisciplinaryRegistry.sol/DisciplinaryRegistry.json";
+
 dotenv.config();
 
+function requireEnv(name: string): string {
+  const value = process.env[name];
+  if (!value) {
+    throw new Error(`Missing ${name} in environment`);
+  }
+  return value;
+}
+
 const RPC = process.env.RPC_URL || "http://127.0.0.1:8545";
-const TRANSFER = process.env.TRANSFER!;
+const TRANSFER = requireEnv("TRANSFER");
+const PRIZE = requireEnv("PRIZE");
+const SPONSOR = requireEnv("SPONSOR");
+const DISCIPLINARY = requireEnv("DISCIPLINARY");
+
 const prisma = new PrismaClient();
 const provider = new ethers.JsonRpcProvider(RPC);
 
-const TRANSFER_EVENT =
-  "event TransferRecorded(uint256 indexed id,uint256 indexed playerId,address indexed fromClub,address toClub,uint256 feeWei,address agent,uint256 agentFeeWei,bytes32 docSha256,string ipfsCid)";
-const iface = new ethers.Interface([TRANSFER_EVENT]);
+const transfer = new ethers.Contract(TRANSFER, TransferRegistryArtifact.abi, provider);
+const prize = new ethers.Contract(PRIZE, PrizePoolArtifact.abi, provider);
+const sponsorship = new ethers.Contract(SPONSOR, SponsorshipRegistryArtifact.abi, provider);
+const disciplinary = new ethers.Contract(DISCIPLINARY, DisciplinaryRegistryArtifact.abi, provider);
 
-async function handleLog(log: ethers.Log) {
-  try {
-    const parsed = iface.parseLog(log)!;
-    const a = parsed.args as any;
-
-    // Get block timestamp (seconds)
-    const block = await provider.getBlock(log.blockHash!);
-    const ts = Number(block?.timestamp ?? Math.floor(Date.now() / 1000));
-
-    await prisma.transfer.upsert({
-      where: { id: Number(a.id) },
-      create: {
-        id: Number(a.id),
-        txHash: log.transactionHash,
-        playerId: Number(a.playerId),
-        fromClub: String(a.fromClub),
-        toClub: String(a.toClub),
-        feeWei: String(a.feeWei),
-        agent: String(a.agent),
-        agentFeeWei: String(a.agentFeeWei),
-        sha256: String(a.docSha256),
-        ipfsCid: String(a.ipfsCid),
-        ts,                                 // <— add this
-      },
-      update: {}, // immutable
-    });
-
-    console.log(`Saved transfer #${a.id} ts=${ts} tx=${log.transactionHash}`);
-  } catch (e) {
-    console.error("indexer save error:", e);
-  }
+async function saveTransfer(event: ethers.EventLog, args: ethers.Result) {
+  const block = await provider.getBlock(event.blockHash!);
+  const ts = Number(block?.timestamp ?? Math.floor(Date.now() / 1000));
+  await prisma.transfer.upsert({
+    where: { id: Number(args.id) },
+    create: {
+      id: Number(args.id),
+      txHash: event.transactionHash,
+      playerId: Number(args.playerId),
+      fromClub: String(args.fromClub),
+      toClub: String(args.toClub),
+      feeWei: String(args.feeWei),
+      agent: String(args.agent),
+      agentFeeWei: String(args.agentFeeWei),
+      sha256: String(args.docSha256),
+      ipfsCid: String(args.ipfsCid),
+      ts,
+    },
+    update: {},
+  });
+  console.log(`Saved transfer #${args.id}`);
 }
 
-console.log("Listening for TransferRecorded on", TRANSFER);
-provider.on(
-  { address: TRANSFER, topics: [iface.getEvent("TransferRecorded")!.topicHash] },
-  handleLog
-);
+async function savePrizeRelease(event: ethers.EventLog, poolId: bigint, to: string, amount: bigint) {
+  await prisma.prizeRelease.create({
+    data: {
+      poolId: Number(poolId),
+      toAddr: to,
+      amount: amount.toString(),
+      txHash: event.transactionHash,
+      ts: Math.floor(Date.now() / 1000),
+    },
+  });
+  console.log(`Saved prize release pool=${poolId} to=${to}`);
+}
+
+async function saveSponsorship(event: ethers.EventLog, args: ethers.Result) {
+  const timestamp = args.ts !== undefined ? Number(args.ts) : Math.floor(Date.now() / 1000);
+  await prisma.sponsorship.upsert({
+    where: { id: Number(args.id) },
+    create: {
+      id: Number(args.id),
+      sponsor: String(args.sponsor),
+      club: String(args.club),
+      amountWei: String(args.amountWei),
+      docSha256: String(args.docSha256),
+      ipfsCid: String(args.ipfsCid),
+      ts: timestamp,
+    },
+    update: {},
+  });
+  console.log(`Saved sponsorship #${args.id}`);
+}
+
+async function saveSanction(event: ethers.EventLog, args: ethers.Result) {
+  const timestamp = args.ts !== undefined ? Number(args.ts) : Math.floor(Date.now() / 1000);
+  await prisma.sanction.upsert({
+    where: { id: Number(args.id) },
+    create: {
+      id: Number(args.id),
+      subject: String(args.subject),
+      kind: String(args.kind),
+      reason: String(args.reason),
+      startDate: Number(args.startDate),
+      endDate: Number(args.endDate),
+      ts: timestamp,
+    },
+    update: {
+      // allow updating timestamps if the contract emits the same ID twice
+      startDate: Number(args.startDate),
+      endDate: Number(args.endDate),
+      reason: String(args.reason),
+    },
+  });
+  console.log(`Saved sanction #${args.id}`);
+}
+
+transfer.on("TransferRecorded", async (...params) => {
+  const event = params[params.length - 1] as ethers.EventLog;
+  const args = event.args as ethers.Result;
+  try {
+    await saveTransfer(event, args);
+  } catch (err) {
+    console.error("transfer index error", err);
+  }
+});
+
+prize.on("PrizeReleased", async (poolId, to, amount, ...rest) => {
+  const event = rest[rest.length - 1] as ethers.EventLog;
+  try {
+    await savePrizeRelease(event, poolId as bigint, to as string, amount as bigint);
+  } catch (err) {
+    console.error("prize index error", err);
+  }
+});
+
+sponsorship.on("SponsorshipRegistered", async (...params) => {
+  const event = params[params.length - 1] as ethers.EventLog;
+  const args = event.args as ethers.Result;
+  try {
+    await saveSponsorship(event, args);
+  } catch (err) {
+    console.error("sponsorship index error", err);
+  }
+});
+
+disciplinary.on("SanctionLogged", async (...params) => {
+  const event = params[params.length - 1] as ethers.EventLog;
+  const args = event.args as ethers.Result;
+  try {
+    await saveSanction(event, args);
+  } catch (err) {
+    console.error("disciplinary index error", err);
+  }
+});
+
+console.log("Indexer listening on", RPC);
+console.log("  transfer:", TRANSFER);
+console.log("  prize:", PRIZE);
+console.log("  sponsorship:", SPONSOR);
+console.log("  disciplinary:", DISCIPLINARY);
+
+process.on("SIGINT", async () => {
+  console.log("Shutting down indexer...");
+  transfer.removeAllListeners();
+  prize.removeAllListeners();
+  sponsorship.removeAllListeners();
+  disciplinary.removeAllListeners();
+  await prisma.$disconnect();
+  process.exit(0);
+});

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -10,7 +10,7 @@ datasource db {
 }
 
 model Transfer {
-  id          Int     @id @default(autoincrement())
+  id          Int     @id
   txHash      String
   playerId    Int
   fromClub    String
@@ -34,7 +34,7 @@ model PrizeRelease {
 }
 
 model Sponsorship {
-  id        Int     @id @default(autoincrement())
+  id        Int     @id
   sponsor   String
   club      String
   amountWei String
@@ -44,7 +44,7 @@ model Sponsorship {
 }
 
 model Sanction {
-  id        Int    @id @default(autoincrement())
+  id        Int    @id
   subject   String
   kind      String
   reason    String

--- a/web/src/pages/Disciplinary.tsx
+++ b/web/src/pages/Disciplinary.tsx
@@ -1,9 +1,14 @@
 import axios from "axios";
 import { useEffect, useState } from "react";
 import type { Abi } from "viem";
-import { createWalletClient, custom } from "viem";
+import { createPublicClient, createWalletClient, custom, http } from "viem";
+import { hardhat } from "viem/chains";
+import { ADDR } from "../utils/env";
+import { ensureConnected31337 } from "../utils/wallet";
 
-const DISCIPLINARY = import.meta.env.VITE_DISCIPLINARY as `0x${string}`;
+const DISCIPLINARY = ADDR.DISCIPLINARY;
+const publicClient = createPublicClient({ chain: hardhat, transport: http("http://127.0.0.1:8545") });
+const H160 = /^0x[0-9a-fA-F]{40}$/;
 
 const DISCIPLINARY_ABI: Abi = [
   { type:"function", name:"logSanction", stateMutability:"nonpayable",
@@ -16,25 +21,54 @@ const DISCIPLINARY_ABI: Abi = [
     ], outputs:[] }
 ];
 
-export default function Disciplinary(){
+export default function Disciplinary() {
   const [list, setList] = useState<any[]>([]);
-  const [form, setForm] = useState({ subject:"", kind:"Suspension", reason:"", start:"", end:"" });
+  const [form, setForm] = useState({ subject: "", kind: "Suspension", reason: "", start: "", end: "" });
 
-  async function refresh(){ setList((await axios.get("http://localhost:4000/sanctions")).data); }
-
-  async function log(){
-    await (window as any).ethereum.request({ method:"eth_requestAccounts" });
-    const wallet = createWalletClient({ transport: custom((window as any).ethereum) });
-    const start = Math.floor(new Date(form.start).getTime()/1000);
-    const end   = Math.floor(new Date(form.end).getTime()/1000);
-    await wallet.writeContract({
-      abi: DISCIPLINARY_ABI, address: DISCIPLINARY, functionName: "logSanction",
-      args: [form.subject as `0x${string}`, form.kind, form.reason, BigInt(start), BigInt(end)]
-    });
-    setTimeout(refresh, 1500);
+  async function refresh() {
+    const { data } = await axios.get("http://localhost:4000/sanctions");
+    setList(data);
   }
 
-  useEffect(()=>{ refresh(); }, []);
+  async function log() {
+    try {
+      await ensureConnected31337();
+      if (!H160.test(form.subject)) throw new Error("Subject must be a valid 0x address");
+      if (!form.start || !form.end) throw new Error("Start and end dates are required");
+      const start = Math.floor(new Date(form.start).getTime() / 1000);
+      const end = Math.floor(new Date(form.end).getTime() / 1000);
+      if (Number.isNaN(start) || Number.isNaN(end)) throw new Error("Invalid dates");
+      if (end < start) throw new Error("End date must be after start date");
+
+      const [account] = await (window as any).ethereum.request({ method: "eth_requestAccounts" });
+      const accountHex = account as `0x${string}`;
+      const wallet = createWalletClient({
+        transport: custom((window as any).ethereum),
+        chain: hardhat,
+        account: accountHex,
+      });
+
+      const { request } = await publicClient.simulateContract({
+        abi: DISCIPLINARY_ABI,
+        address: DISCIPLINARY,
+        functionName: "logSanction",
+        account: accountHex,
+        args: [form.subject as `0x${string}`, form.kind, form.reason, BigInt(start), BigInt(end)],
+      });
+
+      const hash = await wallet.writeContract(request);
+      await publicClient.waitForTransactionReceipt({ hash });
+      alert("✅ Sanction logged");
+      await refresh();
+    } catch (e: any) {
+      console.error(e);
+      alert(e?.shortMessage || e?.details || e?.data?.message || e?.message || String(e));
+    }
+  }
+
+  useEffect(() => {
+    refresh();
+  }, []);
 
   return (
     <div>

--- a/web/src/pages/Prize.tsx
+++ b/web/src/pages/Prize.tsx
@@ -1,90 +1,205 @@
 import axios from "axios";
 import { useEffect, useState } from "react";
 import type { Abi } from "viem";
-import { createWalletClient, custom } from "viem";
+import { createPublicClient, createWalletClient, custom, http, parseEther } from "viem";
+import { hardhat } from "viem/chains";
+import { ADDR } from "../utils/env";
+import { ensureConnected31337 } from "../utils/wallet";
 
-const PRIZE  = import.meta.env.VITE_PRIZE  as `0x${string}`;
-const TOKEN  = import.meta.env.VITE_TOKEN  as `0x${string}`;
+const PRIZE = ADDR.PRIZE;
+const TOKEN = ADDR.TOKEN;
+const publicClient = createPublicClient({ chain: hardhat, transport: http("http://127.0.0.1:8545") });
 
 const TOKEN_ABI: Abi = [
-  { type: "function", name: "approve", stateMutability: "nonpayable",
-    inputs: [{name:"spender",type:"address"},{name:"amount",type:"uint256"}], outputs: [] }
+  {
+    type: "function",
+    name: "approve",
+    stateMutability: "nonpayable",
+    inputs: [
+      { name: "spender", type: "address" },
+      { name: "amount", type: "uint256" },
+    ],
+    outputs: [],
+  },
 ];
 const PRIZE_ABI: Abi = [
-  { type: "function", name: "createPool", stateMutability:"nonpayable",
-    inputs:[{name:"token",type:"address"},{name:"amount",type:"uint256"}], outputs:[{type:"uint256",name:"id"}]},
-  { type: "function", name: "verifyResults", stateMutability:"nonpayable",
-    inputs:[{name:"poolId",type:"uint256"}], outputs:[] },
-  { type: "function", name: "release", stateMutability:"nonpayable",
-    inputs:[
-      {name:"poolId",type:"uint256"},
-      {name:"winners",type:"address[]"},
-      {name:"amounts",type:"uint256[]"}
-    ], outputs:[] }
+  {
+    type: "function",
+    name: "createPool",
+    stateMutability: "nonpayable",
+    inputs: [
+      { name: "token", type: "address" },
+      { name: "amount", type: "uint256" },
+    ],
+    outputs: [{ type: "uint256", name: "id" }],
+  },
+  {
+    type: "function",
+    name: "verifyResults",
+    stateMutability: "nonpayable",
+    inputs: [{ name: "poolId", type: "uint256" }],
+    outputs: [],
+  },
+  {
+    type: "function",
+    name: "release",
+    stateMutability: "nonpayable",
+    inputs: [
+      { name: "poolId", type: "uint256" },
+      { name: "winners", type: "address[]" },
+      { name: "amounts", type: "uint256[]" },
+    ],
+    outputs: [],
+  },
 ];
 
-export default function Prize(){
+const H160 = /^0x[0-9a-fA-F]{40}$/;
+
+export default function Prize() {
   const [poolId, setPoolId] = useState<number>(1);
   const [amountSct, setAmountSct] = useState("1000");
-  const [to1, setTo1] = useState("");  const [amt1, setAmt1] = useState("300");
-  const [to2, setTo2] = useState("");  const [amt2, setAmt2] = useState("700");
+  const [to1, setTo1] = useState("");
+  const [amt1, setAmt1] = useState("300");
+  const [to2, setTo2] = useState("");
+  const [amt2, setAmt2] = useState("700");
   const [releases, setReleases] = useState<any[]>([]);
 
-  async function refresh(){ setReleases((await axios.get("http://localhost:4000/prizes")).data); }
-
-  async function approveAndCreate(){
-    await (window as any).ethereum.request({ method:"eth_requestAccounts" });
-    const wallet = createWalletClient({ transport: custom((window as any).ethereum) });
-
-    await wallet.writeContract({ abi: TOKEN_ABI, address: TOKEN, functionName: "approve",
-      args: [PRIZE, BigInt(Math.floor(parseFloat(amountSct) * 1e18))] });
-
-    await wallet.writeContract({ abi: PRIZE_ABI, address: PRIZE, functionName: "createPool",
-      args: [TOKEN, BigInt(Math.floor(parseFloat(amountSct) * 1e18))] });
-
-    setPoolId(1);
-    setTimeout(refresh, 1500);
+  async function refresh() {
+    const { data } = await axios.get("http://localhost:4000/prizes");
+    setReleases(data);
   }
 
-  async function verifyResults(){
-    const wallet = createWalletClient({ transport: custom((window as any).ethereum) });
-    await wallet.writeContract({ abi: PRIZE_ABI, address: PRIZE, functionName:"verifyResults", args:[BigInt(poolId)] });
+  async function approveAndCreate() {
+    try {
+      await ensureConnected31337();
+      const deposit = parseEther(amountSct || "0");
+      if (deposit <= 0n) throw new Error("Deposit must be greater than zero");
+
+      const [account] = await (window as any).ethereum.request({ method: "eth_requestAccounts" });
+      const accountHex = account as `0x${string}`;
+      const wallet = createWalletClient({
+        transport: custom((window as any).ethereum),
+        chain: hardhat,
+        account: accountHex,
+      });
+
+      const approveHash = await wallet.writeContract({
+        abi: TOKEN_ABI,
+        address: TOKEN,
+        functionName: "approve",
+        args: [PRIZE, deposit],
+        chain: hardhat,
+        account: accountHex,
+      });
+      await publicClient.waitForTransactionReceipt({ hash: approveHash });
+
+      const { request } = await publicClient.simulateContract({
+        abi: PRIZE_ABI,
+        address: PRIZE,
+        functionName: "createPool",
+        account: accountHex,
+        args: [TOKEN, deposit],
+      });
+      const hash = await wallet.writeContract(request);
+      const receipt = await publicClient.waitForTransactionReceipt({ hash });
+      alert("✅ Prize pool created in block " + receipt.blockNumber);
+      await refresh();
+    } catch (e: any) {
+      console.error(e);
+      alert(e?.shortMessage || e?.details || e?.data?.message || e?.message || String(e));
+    }
   }
 
-  async function release(){
-    const wallet = createWalletClient({ transport: custom((window as any).ethereum) });
-    const winners = [to1 as `0x${string}`, to2 as `0x${string}`];
-    const amounts = [
-      BigInt(Math.floor(parseFloat(amt1) * 1e18)),
-      BigInt(Math.floor(parseFloat(amt2) * 1e18))
-    ];
-    await wallet.writeContract({ abi: PRIZE_ABI, address: PRIZE, functionName:"release", args:[BigInt(poolId), winners, amounts] });
-    setTimeout(refresh, 1500);
+  async function verifyResults() {
+    try {
+      await ensureConnected31337();
+      const [account] = await (window as any).ethereum.request({ method: "eth_requestAccounts" });
+      const accountHex = account as `0x${string}`;
+      const wallet = createWalletClient({
+        transport: custom((window as any).ethereum),
+        chain: hardhat,
+        account: accountHex,
+      });
+
+      const { request } = await publicClient.simulateContract({
+        abi: PRIZE_ABI,
+        address: PRIZE,
+        functionName: "verifyResults",
+        account: accountHex,
+        args: [BigInt(poolId)],
+      });
+      const hash = await wallet.writeContract(request);
+      const receipt = await publicClient.waitForTransactionReceipt({ hash });
+      alert("✅ Results verified in block " + receipt.blockNumber);
+    } catch (e: any) {
+      console.error(e);
+      alert(e?.shortMessage || e?.details || e?.data?.message || e?.message || String(e));
+    }
   }
 
-  useEffect(()=>{ refresh(); }, []);
+  async function release() {
+    try {
+      await ensureConnected31337();
+      if (!H160.test(to1) || !H160.test(to2)) throw new Error("Winner addresses must be valid 0x strings");
+      const amountOne = parseEther(amt1 || "0");
+      const amountTwo = parseEther(amt2 || "0");
+      if (amountOne <= 0n || amountTwo <= 0n) throw new Error("Amounts must be greater than zero");
+
+      const [account] = await (window as any).ethereum.request({ method: "eth_requestAccounts" });
+      const accountHex = account as `0x${string}`;
+      const wallet = createWalletClient({
+        transport: custom((window as any).ethereum),
+        chain: hardhat,
+        account: accountHex,
+      });
+
+      const winners = [to1 as `0x${string}`, to2 as `0x${string}`];
+      const amounts = [amountOne, amountTwo];
+
+      const { request } = await publicClient.simulateContract({
+        abi: PRIZE_ABI,
+        address: PRIZE,
+        functionName: "release",
+        account: accountHex,
+        args: [BigInt(poolId), winners, amounts],
+      });
+      const hash = await wallet.writeContract(request);
+      const receipt = await publicClient.waitForTransactionReceipt({ hash });
+      alert("✅ Prize released in block " + receipt.blockNumber);
+      await refresh();
+    } catch (e: any) {
+      console.error(e);
+      alert(e?.shortMessage || e?.details || e?.data?.message || e?.message || String(e));
+    }
+  }
+
+  useEffect(() => {
+    refresh();
+  }, []);
 
   return (
     <div>
       <h2>Prize Pools</h2>
-      <div style={{display:"grid", gridTemplateColumns:"1fr 1fr", gap:12}}>
-        <input placeholder="Deposit (SCT)" value={amountSct} onChange={e=>setAmountSct(e.target.value)}/>
-        <button onClick={approveAndCreate}>Approve & Create Pool</button>
+      <div style={{ display: "grid", gridTemplateColumns: "1fr 1fr", gap: 12 }}>
+        <input placeholder="Deposit (SCT)" value={amountSct} onChange={(e) => setAmountSct(e.target.value)} />
+        <button onClick={approveAndCreate}>Approve &amp; Create Pool</button>
 
-        <input placeholder="Pool ID" value={poolId} onChange={e=>setPoolId(+e.target.value)}/>
+        <input placeholder="Pool ID" value={poolId} onChange={(e) => setPoolId(+e.target.value)} />
         <button onClick={verifyResults}>Verify Results</button>
 
-        <input placeholder="Winner 1 (0x...)" value={to1} onChange={e=>setTo1(e.target.value)}/>
-        <input placeholder="Amount 1 (SCT)" value={amt1} onChange={e=>setAmt1(e.target.value)}/>
-        <input placeholder="Winner 2 (0x...)" value={to2} onChange={e=>setTo2(e.target.value)}/>
-        <input placeholder="Amount 2 (SCT)" value={amt2} onChange={e=>setAmt2(e.target.value)}/>
+        <input placeholder="Winner 1 (0x...)" value={to1} onChange={(e) => setTo1(e.target.value)} />
+        <input placeholder="Amount 1 (SCT)" value={amt1} onChange={(e) => setAmt1(e.target.value)} />
+        <input placeholder="Winner 2 (0x...)" value={to2} onChange={(e) => setTo2(e.target.value)} />
+        <input placeholder="Amount 2 (SCT)" value={amt2} onChange={(e) => setAmt2(e.target.value)} />
         <button onClick={release}>Release</button>
       </div>
 
-      <h3 style={{marginTop:24}}>Released Payouts</h3>
+      <h3 style={{ marginTop: 24 }}>Released Payouts</h3>
       <ul>
-        {releases.map(r=>(
-          <li key={r.id}>Pool {r.poolId} → {r.toAddr} : {r.amount}</li>
+        {releases.map((r) => (
+          <li key={r.id}>
+            Pool {r.poolId} → {r.toAddr} : {r.amount}
+          </li>
         ))}
       </ul>
     </div>

--- a/web/src/pages/Sponsorship.tsx
+++ b/web/src/pages/Sponsorship.tsx
@@ -1,9 +1,15 @@
 import axios from "axios";
 import { useEffect, useState } from "react";
 import type { Abi } from "viem";
-import { createWalletClient, custom } from "viem";
+import { createPublicClient, createWalletClient, custom, http } from "viem";
+import { hardhat } from "viem/chains";
+import { ADDR } from "../utils/env";
+import { ensureConnected31337 } from "../utils/wallet";
 
-const SPONSOR = import.meta.env.VITE_SPONSOR as `0x${string}`;
+const SPONSOR = ADDR.SPONSOR;
+const publicClient = createPublicClient({ chain: hardhat, transport: http("http://127.0.0.1:8545") });
+const ZERO_HASH = "0x".padEnd(66, "0") as `0x${string}`;
+const H160 = /^0x[0-9a-fA-F]{40}$/;
 
 const SPONSOR_ABI: Abi = [
   { type:"function", name:"registerDeal", stateMutability:"nonpayable",
@@ -26,28 +32,61 @@ function fileToBase64(file: File): Promise<string> {
   });
 }
 
-export default function Sponsorship(){
+export default function Sponsorship() {
   const [list, setList] = useState<any[]>([]);
-  const [file, setFile] = useState<File|null>(null);
-  const [form, setForm] = useState({ club:"", amountWei:"10000000000000000", ipfsCid:"" });
+  const [file, setFile] = useState<File | null>(null);
+  const [form, setForm] = useState({ club: "", amountWei: "10000000000000000", ipfsCid: "" });
 
-  async function refresh(){ setList((await axios.get("http://localhost:4000/sponsors")).data); }
-
-  async function register(){
-    let sha256 = "0x";
-    if(file){ sha256 = (await axios.post("http://localhost:4000/hash-file", { base64: await fileToBase64(file)})).data.sha256; }
-
-    await (window as any).ethereum.request({ method:"eth_requestAccounts" });
-    const wallet = createWalletClient({ transport: custom((window as any).ethereum) });
-
-    await wallet.writeContract({
-      abi: SPONSOR_ABI, address: SPONSOR, functionName: "registerDeal",
-      args: [form.club as `0x${string}`, BigInt(form.amountWei), sha256 as `0x${string}`, form.ipfsCid]
-    });
-    setTimeout(refresh, 1500);
+  async function refresh() {
+    const { data } = await axios.get("http://localhost:4000/sponsors");
+    setList(data);
   }
 
-  useEffect(()=>{ refresh(); }, []);
+  async function register() {
+    try {
+      await ensureConnected31337();
+      if (!H160.test(form.club)) throw new Error("Club must be a valid 0x address");
+      const amount = BigInt(form.amountWei || "0");
+      if (amount <= 0n) throw new Error("Amount must be greater than zero");
+
+      let sha256: `0x${string}` = ZERO_HASH;
+      if (file) {
+        const base64 = await fileToBase64(file);
+        const response = await axios.post("http://localhost:4000/hash-file", { base64 });
+        if (!/^0x[0-9a-fA-F]{64}$/.test(response?.data?.sha256)) throw new Error("Bad hash from API");
+        sha256 = response.data.sha256;
+      }
+
+      const [account] = await (window as any).ethereum.request({ method: "eth_requestAccounts" });
+      const accountHex = account as `0x${string}`;
+      const wallet = createWalletClient({
+        transport: custom((window as any).ethereum),
+        chain: hardhat,
+        account: accountHex,
+      });
+
+      const { request } = await publicClient.simulateContract({
+        abi: SPONSOR_ABI,
+        address: SPONSOR,
+        functionName: "registerDeal",
+        account: accountHex,
+        args: [form.club as `0x${string}`, amount, sha256, form.ipfsCid],
+      });
+
+      const hash = await wallet.writeContract(request);
+      await publicClient.waitForTransactionReceipt({ hash });
+      alert("✅ Sponsorship registered");
+      setFile(null);
+      await refresh();
+    } catch (e: any) {
+      console.error(e);
+      alert(e?.shortMessage || e?.details || e?.data?.message || e?.message || String(e));
+    }
+  }
+
+  useEffect(() => {
+    refresh();
+  }, []);
 
   return (
     <div>

--- a/web/src/pages/Transfers.tsx
+++ b/web/src/pages/Transfers.tsx
@@ -2,32 +2,15 @@ import { hardhat } from "viem/chains";
 import { createPublicClient, http } from "viem";
 import axios from "axios";
 import { useEffect, useState } from "react";
-import type { Abi, ContractFunctionParameters } from "viem";
+import type { Abi } from "viem";
 import { createWalletClient, custom } from "viem";
 import { ADDR } from "../utils/env";
 import { ensureConnected31337 } from "../utils/wallet";
+import TransferRegistryArtifact from "@artifacts/contracts/TransferRegistry.sol/TransferRegistry.json";
 
 const TRANSFER = ADDR.TRANSFER;
 const publicClient = createPublicClient({ chain: hardhat, transport: http("http://127.0.0.1:8545") });
-
-// Minimal ABI (only what we call)
-const TRANSFER_ABI: Abi = [
-  {
-    type: "function",
-    name: "recordTransfer",
-    stateMutability: "nonpayable",
-    inputs: [
-      { name: "playerId", type: "uint256" },
-      { name: "toClub", type: "address" },
-      { name: "feeWei", type: "uint256" },
-      { name: "agent", type: "address" },
-      { name: "agentFeeWei", type: "uint256" },
-      { name: "docSha256", type: "bytes32" },
-      { name: "ipfsCid", type: "string" }
-    ],
-    outputs: [{ name: "id", type: "uint256" }]
-  }
-];
+const TRANSFER_ABI = TransferRegistryArtifact.abi as Abi;
 
 // Helper: read a File as base64 (browser-safe, no Buffer needed)
 function fileToBase64(file: File): Promise<string> {
@@ -56,62 +39,66 @@ export default function Transfers(){
     setList(data);
   }
 
-async function record() {
-  try {
-    await ensureConnected31337();
+  async function record() {
+    try {
+      await ensureConnected31337();
 
-    // validate inputs
-    const addr = /^0x[0-9a-fA-F]{40}$/;
-    if (!addr.test(form.toClub)) throw new Error("Invalid 'To Club' address");
-    if (!addr.test(form.agent))  throw new Error("Invalid 'Agent' address");
+      // validate inputs
+      const addr = /^0x[0-9a-fA-F]{40}$/;
+      if (!addr.test(form.toClub)) throw new Error("Invalid 'To Club' address");
+      if (!addr.test(form.agent)) throw new Error("Invalid 'Agent' address");
 
-    const playerId    = BigInt(form.playerId);
-    const feeWei      = BigInt(form.feeWei || "0");
-    const agentFeeWei = BigInt(form.agentFeeWei || "0");
+      const playerId = BigInt(form.playerId);
+      const feeWei = BigInt(form.feeWei || "0");
+      const agentFeeWei = BigInt(form.agentFeeWei || "0");
 
-    // optional file hash
-    let sha256: `0x${string}` = "0x0000000000000000000000000000000000000000000000000000000000000000";
-    if (file) {
-      const b64 = await fileToBase64(file);
-      const r = await axios.post("http://localhost:4000/hash-file", { base64: b64 });
-      if (!/^0x[0-9a-fA-F]{64}$/.test(r?.data?.sha256)) throw new Error("Bad hash from API");
-      sha256 = r.data.sha256;
+      // optional file hash
+      let sha256: `0x${string}` = "0x0000000000000000000000000000000000000000000000000000000000000000";
+      if (file) {
+        const b64 = await fileToBase64(file);
+        const r = await axios.post("http://localhost:4000/hash-file", { base64: b64 });
+        if (!/^0x[0-9a-fA-F]{64}$/.test(r?.data?.sha256)) throw new Error("Bad hash from API");
+        sha256 = r.data.sha256;
+      }
+
+      const [account] = await (window as any).ethereum.request({ method: "eth_requestAccounts" });
+
+      const { request } = await publicClient.simulateContract({
+        abi: TRANSFER_ABI,
+        address: TRANSFER,
+        functionName: "recordTransfer",
+        account: account as `0x${string}`,
+        args: [
+          playerId,
+          form.toClub as `0x${string}`,
+          feeWei,
+          form.agent as `0x${string}`,
+          agentFeeWei,
+          sha256,
+          form.ipfsCid || "",
+        ],
+      });
+
+      const wallet = createWalletClient({
+        transport: custom((window as any).ethereum),
+        chain: hardhat,
+        account: account as `0x${string}`,
+      });
+
+      const hash = await wallet.writeContract(request);
+
+      // ⬇️ wait here until mined (or throws on revert)
+      const receipt = await publicClient.waitForTransactionReceipt({ hash });
+      console.log("Tx mined:", receipt);
+
+      alert("✅ Transfer confirmed in block " + receipt.blockNumber);
+      setFile(null);
+      await refresh(); // indexer should have picked the event by now
+    } catch (e: any) {
+      console.error(e);
+      alert(e?.shortMessage || e?.details || e?.data?.message || e?.message || String(e));
     }
-
-    const [account] = await (window as any).ethereum.request({ method: "eth_requestAccounts" });
-
-    const wallet = createWalletClient({
-      transport: custom((window as any).ethereum),
-      chain: hardhat,
-      account: account as `0x${string}`,
-    });
-
-    const hash = await wallet.writeContract({
-      abi: TRANSFER_ABI,
-      address: TRANSFER,
-      functionName: "recordTransfer",
-      args: [
-        playerId,
-        form.toClub as `0x${string}`,
-        feeWei,
-        form.agent as `0x${string}`,
-        agentFeeWei,
-        sha256,
-        form.ipfsCid || ""
-      ]
-    });
-
-    // ⬇️ wait here until mined (or throws on revert)
-    const receipt = await publicClient.waitForTransactionReceipt({ hash });
-    console.log("Tx mined:", receipt);
-
-    alert("✅ Transfer confirmed in block " + receipt.blockNumber);
-    await refresh(); // indexer should have picked the event by now
-  } catch (e: any) {
-    console.error(e);
-    alert(e?.shortMessage || e?.data?.message || e?.message || String(e));
   }
-}
 
 
   useEffect(()=>{ refresh(); }, []);
@@ -132,9 +119,15 @@ async function record() {
 
       <h3 style={{marginTop:24}}>Recent Transfers</h3>
       <ul>
-        {list.map(t=>(
+        {list.map((t) => (
           <li key={t.id}>
-            #{t.id} Player {t.playerId} {t.fromClub} → {t.toClub} | Fee {t.feeWei} | SHA256 {t.docSha256?.slice(0,10)}… {t.ipfsCid && <a href={`https://ipfs.io/ipfs/${t.ipfsCid}`} target="_blank">doc</a>}
+            #{t.id} Player {t.playerId} {t.fromClub} → {t.toClub} | Fee {t.feeWei} | SHA256 {t.sha256?.slice(0, 10)}…
+            {" "}
+            {t.ipfsCid && (
+              <a href={`https://ipfs.io/ipfs/${t.ipfsCid}`} target="_blank" rel="noreferrer">
+                doc
+              </a>
+            )}
           </li>
         ))}
       </ul>

--- a/web/tsconfig.app.json
+++ b/web/tsconfig.app.json
@@ -5,6 +5,10 @@
     "useDefineForClassFields": true,
     "lib": ["ES2022", "DOM", "DOM.Iterable"],
     "module": "ESNext",
+    "baseUrl": ".",
+    "paths": {
+      "@artifacts/*": ["../artifacts/*"]
+    },
     "skipLibCheck": true,
 
     /* Bundler mode */

--- a/web/vite.config.ts
+++ b/web/vite.config.ts
@@ -1,7 +1,18 @@
 import { defineConfig } from 'vite'
 import react from '@vitejs/plugin-react'
+import path from 'path'
 
 // https://vite.dev/config/
 export default defineConfig({
   plugins: [react()],
+  resolve: {
+    alias: {
+      '@artifacts': path.resolve(__dirname, '../artifacts'),
+    },
+  },
+  server: {
+    fs: {
+      allow: [path.resolve(__dirname, '..')],
+    },
+  },
 })


### PR DESCRIPTION
## Summary
- rebuild the Node indexer to pull event data for transfers, prize payouts, sponsorships, and sanctions directly from the deployed contract ABIs
- align Prisma models with deterministic on-chain IDs so event upserts are stable
- harden the transfer, prize, sponsorship, and disciplinary forms to validate inputs, simulate calls, and wait on receipts before refreshing

## Testing
- npx prisma generate
- npx prisma db push
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68c9787152d0832d9e13c4bc79b33ac2