### PR TITLE
Fix transfer list SHA display

### DIFF
--- a/web/src/pages/Transfers.tsx
+++ b/web/src/pages/Transfers.tsx
@@ -121,7 +121,7 @@ export default function Transfers(){
       <ul>
         {list.map((t) => (
           <li key={t.id}>
-            #{t.id} Player {t.playerId} {t.fromClub} → {t.toClub} | Fee {t.feeWei} | SHA256 {t.sha256?.slice(0, 10)}…
+            #{t.id} Player {t.playerId} {t.fromClub} → {t.toClub} | Fee {t.feeWei} | SHA256 {t.docSha256?.slice(0, 10)}…
             {" "}
             {t.ipfsCid && (
               <a href={`https://ipfs.io/ipfs/${t.ipfsCid}`} target="_blank" rel="noreferrer">


### PR DESCRIPTION
## Summary
- update the Transfers page to render SHA hashes using the docSha256 field from the API

## Testing
- npm --prefix web run build

------
https://chatgpt.com/codex/tasks/task_e_68c98f4a5834832da00afe8c15081acf