### PR TITLE
Fix transfer submission nonce handling

### DIFF
--- a/web/src/pages/Transfers.tsx
+++ b/web/src/pages/Transfers.tsx
@@ -62,12 +62,18 @@ export default function Transfers(){
       }
 
       const [account] = await (window as any).ethereum.request({ method: "eth_requestAccounts" });
+      const from = account as `0x${string}`;
+
+      const nonce = await publicClient.getTransactionCount({
+        address: from,
+        blockTag: "pending",
+      });
 
       const { request } = await publicClient.simulateContract({
         abi: TRANSFER_ABI,
         address: TRANSFER,
         functionName: "recordTransfer",
-        account: account as `0x${string}`,
+        account: from,
         args: [
           playerId,
           form.toClub as `0x${string}`,
@@ -82,10 +88,10 @@ export default function Transfers(){
       const wallet = createWalletClient({
         transport: custom((window as any).ethereum),
         chain: hardhat,
-        account: account as `0x${string}`,
+        account: from,
       });
 
-      const hash = await wallet.writeContract(request);
+      const hash = await wallet.writeContract({ ...request, nonce });
 
       // ⬇️ wait here until mined (or throws on revert)
       const receipt = await publicClient.waitForTransactionReceipt({ hash });


### PR DESCRIPTION
## Summary
- read the pending transaction count for the connected wallet before sending a transfer
- include the fetched nonce in the transfer write request so MetaMask signs with the correct sequence number

## Testing
- npm run build (in web)


------
https://chatgpt.com/codex/tasks/task_e_68c9ad72751c832d9665af46d8b6cb72