### PR TITLE
Handle circuit breaker reverts when recording transfers

### DIFF
--- a/web/src/pages/Transfers.tsx
+++ b/web/src/pages/Transfers.tsx
@@ -1,16 +1,22 @@
 import { hardhat } from "viem/chains";
 import { createPublicClient, http } from "viem";
 import axios from "axios";
-import { useEffect, useState } from "react";
+import { useCallback, useEffect, useState } from "react";
 import type { Abi } from "viem";
 import { createWalletClient, custom } from "viem";
 import { ADDR } from "../utils/env";
 import { ensureConnected31337 } from "../utils/wallet";
 import TransferRegistryArtifact from "@artifacts/contracts/TransferRegistry.sol/TransferRegistry.json";
+import RoleManagerArtifact from "@artifacts/contracts/RoleManager.sol/RoleManager.json";
 
 const TRANSFER = ADDR.TRANSFER;
+const ROLE_MANAGER = ADDR.ROLES;
 const publicClient = createPublicClient({ chain: hardhat, transport: http("http://127.0.0.1:8545") });
 const TRANSFER_ABI = TransferRegistryArtifact.abi as Abi;
+const ROLE_MANAGER_ABI = RoleManagerArtifact.abi as Abi;
+const TRANSFER_SUPPORTS_PAUSE = TRANSFER_ABI.some(
+  (entry) => entry.type === "function" && (entry as any).name === "paused",
+);
 
 // Helper: read a File as base64 (browser-safe, no Buffer needed)
 function fileToBase64(file: File): Promise<string> {
@@ -20,6 +26,10 @@ function fileToBase64(file: File): Promise<string> {
     fr.onerror = reject;
     fr.readAsDataURL(file);
   });
+}
+
+function friendlyError(err: any): string {
+  return err?.shortMessage || err?.details || err?.data?.message || err?.message || String(err);
 }
 
 export default function Transfers(){
@@ -33,15 +43,175 @@ export default function Transfers(){
     agentFeeWei: "0",
     ipfsCid: ""
   });
+  const [circuitOpen, setCircuitOpen] = useState(false);
+  const [circuitSource, setCircuitSource] = useState({ roles: false, registry: false });
+  const [checkingCircuit, setCheckingCircuit] = useState(false);
+  const [resuming, setResuming] = useState(false);
+  const [submitting, setSubmitting] = useState(false);
+  const [wallet, setWallet] = useState<{ address: `0x${string}` | null; isAdmin: boolean }>({ address: null, isAdmin: false });
 
-  async function refresh() {
-    const { data } = await axios.get("http://localhost:4000/transfers");
+  const refresh = useCallback(async (): Promise<any[]> => {
+    const response = await axios.get("http://localhost:4000/transfers");
+    const data = Array.isArray(response.data) ? response.data : [];
     setList(data);
+    return data;
+  }, []);
+
+  async function waitForIndexer(txHash: `0x${string}`): Promise<any> {
+    const target = txHash.toLowerCase();
+    const attempts = 12;
+    for (let i = 0; i < attempts; i++) {
+      try {
+        const rows = await refresh();
+        const match = rows.find((row: any) => typeof row?.txHash === "string" && row.txHash.toLowerCase() === target);
+        if (match) {
+          return match;
+        }
+      } catch (err: any) {
+        if (i === attempts - 1) {
+          throw new Error(`Transfer confirmed on-chain but failed to query the indexer: ${friendlyError(err)}`);
+        }
+      }
+      if (i !== attempts - 1) {
+        await new Promise((resolve) => setTimeout(resolve, 1000));
+      }
+    }
+    throw new Error(
+      "Transfer confirmed on-chain but the indexer hasn't stored it yet. It may still be syncing—please wait a few seconds and refresh the Transfers list.",
+    );
+  }
+
+  const refreshWalletStatus = useCallback(async (): Promise<{ address: `0x${string}` | null; isAdmin: boolean }> => {
+    const eth = (window as any).ethereum;
+    let info: { address: `0x${string}` | null; isAdmin: boolean } = { address: null, isAdmin: false };
+    if (!eth) {
+      setWallet(info);
+      return info;
+    }
+    try {
+      const accounts = (await eth.request({ method: "eth_accounts" })) as string[] | undefined;
+      const address = (accounts?.[0] ?? null) as `0x${string}` | null;
+      if (!address) {
+        setWallet(info);
+        return info;
+      }
+      let isAdmin = false;
+      try {
+        const adminRole = (await publicClient.readContract({
+          abi: ROLE_MANAGER_ABI,
+          address: ROLE_MANAGER,
+          functionName: "ADMIN_ROLE",
+        })) as `0x${string}`;
+        isAdmin = (await publicClient.readContract({
+          abi: ROLE_MANAGER_ABI,
+          address: ROLE_MANAGER,
+          functionName: "hasRole",
+          args: [adminRole, address],
+        })) as boolean;
+      } catch (err) {
+        console.warn("admin role lookup failed", err);
+      }
+      info = { address, isAdmin };
+      setWallet(info);
+      return info;
+    } catch (err) {
+      console.warn("wallet status check failed", err);
+      setWallet(info);
+      return info;
+    }
+  }, []);
+
+  async function refreshCircuit(): Promise<boolean> {
+    setCheckingCircuit(true);
+    let rolesPaused = false;
+    let registryPaused = false;
+    try {
+      try {
+        rolesPaused = Boolean(await publicClient.readContract({
+          abi: ROLE_MANAGER_ABI,
+          address: ROLE_MANAGER,
+          functionName: "paused",
+        }));
+      } catch (err) {
+        console.warn("roles pause probe failed", err);
+      }
+      if (TRANSFER_SUPPORTS_PAUSE) {
+        try {
+          registryPaused = Boolean(await publicClient.readContract({
+            abi: TRANSFER_ABI,
+            address: TRANSFER,
+            functionName: "paused",
+          }));
+        } catch (err) {
+          console.warn("transfer pause probe failed", err);
+        }
+      }
+      return rolesPaused || registryPaused;
+    } finally {
+      setCircuitSource({ roles: rolesPaused, registry: registryPaused });
+      setCircuitOpen(rolesPaused || registryPaused);
+      setCheckingCircuit(false);
+    }
+  }
+
+  async function resumeTransfers() {
+    try {
+      setResuming(true);
+      await ensureConnected31337();
+      const info = await refreshWalletStatus();
+      if (!info.address) {
+        throw new Error("Connect a wallet with the admin role to resume transfers");
+      }
+      if (!info.isAdmin) {
+        throw new Error("Only an administrator can close the circuit breaker");
+      }
+      const nonce = await publicClient.getTransactionCount({
+        address: info.address,
+        blockTag: "pending",
+      });
+      const { request } = await publicClient.simulateContract({
+        abi: ROLE_MANAGER_ABI,
+        address: ROLE_MANAGER,
+        functionName: "unpause",
+        account: info.address,
+      });
+      const walletClient = createWalletClient({
+        transport: custom((window as any).ethereum),
+        chain: hardhat,
+        account: info.address,
+      });
+      const hash = await walletClient.writeContract({ ...request, nonce });
+      await publicClient.waitForTransactionReceipt({ hash });
+      await refreshCircuit();
+      alert("✅ Transfers resumed. You can submit new transfers now.");
+    } catch (err) {
+      console.error(err);
+      alert(friendlyError(err));
+    } finally {
+      setResuming(false);
+    }
   }
 
   async function record() {
+    let lastWalletInfo: { address: `0x${string}` | null; isAdmin: boolean } | null = null;
     try {
+      setSubmitting(true);
       await ensureConnected31337();
+
+      const walletInfo = await refreshWalletStatus();
+      lastWalletInfo = walletInfo;
+      const from = walletInfo.address;
+      if (!from) {
+        throw new Error("Unable to determine connected wallet address");
+      }
+
+      const stillOpen = await refreshCircuit();
+      if (stillOpen) {
+        if (walletInfo.isAdmin) {
+          throw new Error("Transfers are paused. Close the circuit breaker with the Resume button before submitting.");
+        }
+        throw new Error("Transfers are currently paused by administrators. Please try again after the circuit breaker is closed.");
+      }
 
       // validate inputs
       const addr = /^0x[0-9a-fA-F]{40}$/;
@@ -61,13 +231,33 @@ export default function Transfers(){
         sha256 = r.data.sha256;
       }
 
-      const [account] = await (window as any).ethereum.request({ method: "eth_requestAccounts" });
+      const clubRole = (await publicClient.readContract({
+        abi: TRANSFER_ABI,
+        address: TRANSFER,
+        functionName: "CLUB_ROLE",
+      })) as `0x${string}`;
+
+      const hasClubRole = (await publicClient.readContract({
+        abi: TRANSFER_ABI,
+        address: TRANSFER,
+        functionName: "hasRole",
+        args: [clubRole, from],
+      })) as boolean;
+
+      if (!hasClubRole) {
+        throw new Error("Connected wallet is not authorised to record transfers");
+      }
+
+      const nonce = await publicClient.getTransactionCount({
+        address: from,
+        blockTag: "pending",
+      });
 
       const { request } = await publicClient.simulateContract({
         abi: TRANSFER_ABI,
         address: TRANSFER,
         functionName: "recordTransfer",
-        account: account as `0x${string}`,
+        account: from,
         args: [
           playerId,
           form.toClub as `0x${string}`,
@@ -82,31 +272,108 @@ export default function Transfers(){
       const wallet = createWalletClient({
         transport: custom((window as any).ethereum),
         chain: hardhat,
-        account: account as `0x${string}`,
+        account: from,
       });
 
-      const hash = await wallet.writeContract(request);
+      const hash = await wallet.writeContract({ ...request, nonce });
 
       // ⬇️ wait here until mined (or throws on revert)
       const receipt = await publicClient.waitForTransactionReceipt({ hash });
+      if (receipt.status !== "success") {
+        throw new Error("Transaction reverted on-chain. Check wallet role and try again.");
+      }
       console.log("Tx mined:", receipt);
 
-      alert("✅ Transfer confirmed in block " + receipt.blockNumber);
+      const indexed = await waitForIndexer(hash);
+
       setFile(null);
-      await refresh(); // indexer should have picked the event by now
+      alert(`✅ Transfer #${indexed.id} confirmed in block ${receipt.blockNumber}`);
+      await refreshCircuit();
     } catch (e: any) {
       console.error(e);
-      alert(e?.shortMessage || e?.details || e?.data?.message || e?.message || String(e));
+      const message = friendlyError(e);
+      if (/circuit breaker is open|Pausable: paused/i.test(message)) {
+        setCircuitOpen(true);
+        try {
+          await refreshCircuit();
+        } catch (refreshErr) {
+          console.warn("refresh circuit after revert failed", refreshErr);
+        }
+        const info = lastWalletInfo ?? wallet;
+        const guidance = info.isAdmin
+          ? "Use the Resume transfers button to close the circuit breaker before submitting."
+          : "Please contact an administrator to resume transfers before submitting.";
+        alert(`Transfers are paused. ${guidance}`);
+        return;
+      }
+      alert(message);
+    } finally {
+      setSubmitting(false);
     }
   }
 
+  useEffect(() => { void refreshWalletStatus(); }, [refreshWalletStatus]);
 
-  useEffect(()=>{ refresh(); }, []);
+  useEffect(() => {
+    const eth = (window as any).ethereum;
+    if (!eth?.on) {
+      return;
+    }
+    const handler = () => {
+      void refreshWalletStatus();
+      void refreshCircuit();
+    };
+    eth.on("accountsChanged", handler);
+    eth.on("chainChanged", handler);
+    return () => {
+      eth.removeListener?.("accountsChanged", handler);
+      eth.removeListener?.("chainChanged", handler);
+    };
+  }, [refreshWalletStatus]);
+
+  useEffect(() => {
+    void refresh();
+    void refreshCircuit();
+  }, [refresh]);
 
   return (
     <div>
       <h2>Record Transfer</h2>
       <div style={{display:"grid", gridTemplateColumns:"1fr 1fr", gap:12}}>
+        {circuitOpen && (
+          <div
+            style={{
+              gridColumn: "1 / -1",
+              background: "#fff2f0",
+              color: "#7a1f1f",
+              padding: 12,
+              borderRadius: 6,
+              lineHeight: 1.4,
+            }}
+          >
+            <strong>Circuit breaker active.</strong>
+            <div style={{ marginTop: 4 }}>
+              Transfers are temporarily paused by administrators.
+              {wallet.isAdmin ? " Use the button below to resume transfers." : " Only an administrator can resume transfers."}
+            </div>
+            <div style={{ display: "flex", gap: 8, flexWrap: "wrap", marginTop: 8 }}>
+              <button onClick={() => { void refreshCircuit(); }} disabled={checkingCircuit}>
+                {checkingCircuit ? "Checking…" : "Refresh status"}
+              </button>
+              {wallet.isAdmin && (
+                <button onClick={() => { void resumeTransfers(); }} disabled={resuming || checkingCircuit}>
+                  {resuming ? "Resuming…" : "Resume transfers"}
+                </button>
+              )}
+            </div>
+            {(circuitSource.roles || circuitSource.registry) && (
+              <div style={{ fontSize: 12, marginTop: 6, opacity: 0.85 }}>
+                {circuitSource.roles && "Role manager pause is active."}
+                {circuitSource.registry && `${circuitSource.roles ? " " : ""}Transfer registry pause is active.`}
+              </div>
+            )}
+          </div>
+        )}
         <input placeholder="Player ID" value={form.playerId} onChange={e=>setForm({...form, playerId: +e.target.value})}/>
         <input placeholder="To Club (0x...)" value={form.toClub} onChange={e=>setForm({...form, toClub: e.target.value})}/>
         <input placeholder="Fee (wei)" value={form.feeWei} onChange={e=>setForm({...form, feeWei: e.target.value})}/>
@@ -114,7 +381,9 @@ export default function Transfers(){
         <input placeholder="Agent Fee (wei)" value={form.agentFeeWei} onChange={e=>setForm({...form, agentFeeWei: e.target.value})}/>
         <input placeholder="IPFS CID (optional)" value={form.ipfsCid} onChange={e=>setForm({...form, ipfsCid: e.target.value})}/>
         <input type="file" onChange={e=>setFile(e.target.files?.[0] || null)} />
-        <button onClick={record}>Submit</button>
+        <button onClick={record} disabled={submitting || circuitOpen || checkingCircuit || resuming}>
+          {circuitOpen ? "Transfers paused" : submitting ? "Submitting…" : "Submit"}
+        </button>
       </div>
 
       <h3 style={{marginTop:24}}>Recent Transfers</h3>


### PR DESCRIPTION
## Summary
- retain the last wallet info during submissions so circuit breaker errors can surface admin guidance
- detect circuit breaker reverts, refresh the breaker status, and present a friendly pause message instead of propagating the raw revert

## Testing
- npm run build (in web)


------
https://chatgpt.com/codex/tasks/task_e_68c9ad72751c832d9665af46d8b6cb72